### PR TITLE
feat: Support more CLI flags for `build` and `dev`

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -1,11 +1,16 @@
 {
-  "name": "Demo Extension",
+  "name": "Demo",
   "version": "1.0.0",
   "description": "Demo extension for WXT",
   "type": "module",
   "scripts": {
     "dev": "pnpm -w build && wxt",
     "build": "pnpm -w build && wxt build",
+    "build:all": "pnpm -w build && run-s -s build:all:*",
+    "build:all:chrome-mv3": "wxt build",
+    "build:all:chrome-mv2": "wxt build --mv2",
+    "build:all:firefox-mv3": "wxt build -b firefox --mv3",
+    "build:all:firefox-mv2": "wxt build -b firefox",
     "prepare": "pnpm -w build && wxt prepare"
   },
   "dependencies": {

--- a/src/cli/commands/build.ts
+++ b/src/cli/commands/build.ts
@@ -1,12 +1,26 @@
 import * as wxt from '../..';
-import { getInternalConfig } from '../../utils/getInternalConfig';
 import { defineCommand } from '../utils/defineCommand';
 
-export const build = defineCommand(
-  async (root: any, { mode, config: configFile }: any) => {
-    const cliConfig: wxt.InlineConfig = { root, mode, configFile };
-    const config = await getInternalConfig(cliConfig, mode);
+export const build = defineCommand<
+  [
+    root: string | undefined,
+    flags: {
+      mode?: string;
+      config?: string;
+      browser?: wxt.TargetBrowser;
+      mv3?: boolean;
+      mv2?: boolean;
+    },
+  ]
+>(async (root, flags) => {
+  const mode = flags.mode ?? 'production';
+  const cliConfig: wxt.InlineConfig = {
+    root,
+    mode,
+    browser: flags.browser,
+    manifestVersion: flags.mv3 ? 3 : flags.mv2 ? 2 : undefined,
+    configFile: flags.config,
+  };
 
-    await wxt.build(config);
-  },
-);
+  await wxt.build(cliConfig);
+});

--- a/src/cli/commands/dev.ts
+++ b/src/cli/commands/dev.ts
@@ -1,17 +1,29 @@
 import * as wxt from '../..';
 import { defineCommand } from '../utils/defineCommand';
 
-export const dev = defineCommand(
-  async (root: any, { mode, config: configFile }: any) => {
-    const cliConfig: wxt.InlineConfig = {
-      mode,
-      root,
-      configFile,
-    };
-    const server = await wxt.createServer(cliConfig);
+export const dev = defineCommand<
+  [
+    root: string | undefined,
+    flags: {
+      mode?: string;
+      config?: string;
+      browser?: wxt.TargetBrowser;
+      mv3?: boolean;
+      mv2?: boolean;
+    },
+  ]
+>(async (root, flags) => {
+  const mode = flags.mode ?? 'development';
+  const cliConfig: wxt.InlineConfig = {
+    root,
+    mode,
+    browser: flags.browser,
+    manifestVersion: flags.mv3 ? 3 : flags.mv2 ? 2 : undefined,
+    configFile: flags.config,
+  };
 
-    await server.listen(server.port);
-    server.logger.success(`Started dev server @ ${server.origin}`);
-    return true;
-  },
-);
+  const server = await wxt.createServer(cliConfig);
+  await server.listen(server.port);
+  server.logger.success(`Started dev server @ ${server.origin}`);
+  return true;
+});

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -1,6 +1,6 @@
 import { consola } from 'consola';
 import { defineCommand } from '../utils/defineCommand';
 
-export const init = defineCommand(async (directory: any) => {
+export const init = defineCommand<[directory?: string]>(async (directory) => {
   consola.warn('wxt init: Not implemented');
 });

--- a/src/cli/commands/prepare.ts
+++ b/src/cli/commands/prepare.ts
@@ -4,14 +4,22 @@ import { generateTypesDir } from '../../utils/generateTypesDir';
 import { defineCommand } from '../utils/defineCommand';
 import * as wxt from '../..';
 
-export const prepare = defineCommand(
-  async (root: any, { mode, config: configFile }: any) => {
-    const cliConfig: wxt.InlineConfig = { root, mode, configFile };
-    const config = await getInternalConfig(cliConfig, 'build');
+export const prepare = defineCommand<
+  [
+    root: string | undefined,
+    flags: {
+      config?: string;
+    },
+  ]
+>(async (root, flags) => {
+  const cliConfig: wxt.InlineConfig = {
+    root,
+    configFile: flags.config,
+  };
+  const config = await getInternalConfig(cliConfig, 'build');
 
-    config.logger.info('Generating types...');
+  config.logger.info('Generating types...');
 
-    const entrypoints = await findEntrypoints(config);
-    await generateTypesDir(entrypoints, config);
-  },
-);
+  const entrypoints = await findEntrypoints(config);
+  await generateTypesDir(entrypoints, config);
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -12,12 +12,10 @@ cli.version(version);
 cli
   .command('[root]', 'start dev server')
   .option('-c, --config <file>', 'use specified config file')
-  .option('-b, --browser <browser>', 'specify a browser', {
-    type: ['chrome', 'firefox'],
-  })
-  .option('-m, --mode <mode>', 'set env mode', {
-    default: 'development',
-  })
+  .option('-m, --mode <mode>', 'set env mode')
+  .option('-b, --browser <browser>', 'specify a browser')
+  .option('--mv3', 'target manifest v3')
+  .option('--mv2', 'target manifest v2')
   .action(commands.dev);
 
 // BUILD
@@ -25,15 +23,15 @@ cli
   .command('build [root]', 'build for production')
   .option('-c, --config <file>', 'use specified config file')
   .option('-m, --mode <mode>', 'set env mode')
+  .option('-b, --browser <browser>', 'specify a browser')
+  .option('--mv3', 'target manifest v3')
+  .option('--mv2', 'target manifest v2')
   .action(commands.build);
 
 // PREPARE
 cli
   .command('prepare [root]', 'prepare')
   .option('-c, --config <file>', 'use specified config file')
-  .option('-m, --mode <mode>', 'set env mode', {
-    default: 'production',
-  })
   .action(commands.prepare);
 
 // PUBLISH

--- a/src/cli/utils/defineCommand.ts
+++ b/src/cli/utils/defineCommand.ts
@@ -2,10 +2,10 @@ import { consola } from 'consola';
 import { printHeader } from './printHeader';
 import { formatDuration } from '../../utils/formatDuration';
 
-export function defineCommand(
-  cb: (...args: any[]) => void | boolean | Promise<void | boolean>,
+export function defineCommand<TArgs extends any[]>(
+  cb: (...args: TArgs) => void | boolean | Promise<void | boolean>,
 ) {
-  return async (...args: any[]) => {
+  return async (...args: TArgs) => {
     const startTime = Date.now();
     try {
       printHeader();


### PR DESCRIPTION
This closes #8. Also adds more support for other CLI flags, like the browser and manifest version, which were supported by build but not passed into it from the CLI.