### PR TITLE
fix: Remove hash from content script css outputs

### DIFF
--- a/e2e/tests/manifest-content.test.ts
+++ b/e2e/tests/manifest-content.test.ts
@@ -191,21 +191,18 @@ describe('Manifest Content', () => {
     expect(manifest.content_scripts).toContainEqual({
       matches: ['*://duckduckgo.com/*'],
       run_at: 'document_end',
-      css: [expect.stringContaining('assets/four-')],
+      css: ['assets/four.css'],
       js: ['content-scripts/four.js'],
     });
     expect(manifest.content_scripts).toContainEqual({
       matches: ['*://google.com/*'],
       run_at: 'document_end',
-      css: [
-        expect.stringContaining('assets/three-'),
-        expect.stringContaining('assets/two-'),
-      ],
+      css: ['assets/three.css', 'assets/two.css'],
       js: ['content-scripts/three.js', 'content-scripts/two.js'],
     });
     expect(manifest.content_scripts).toContainEqual({
       matches: ['*://google.com/*'],
-      css: [expect.stringContaining('assets/one-')],
+      css: ['assets/one.css'],
       js: ['content-scripts/one.js'],
     });
   });

--- a/e2e/tests/output-structure.test.ts
+++ b/e2e/tests/output-structure.test.ts
@@ -44,12 +44,12 @@ describe('Output Directory Structure', () => {
     await project.build();
 
     expect(await project.serializeOutput()).toMatchInlineSnapshot(`
-      ".output/chrome-mv3/assets/one-dedc7a05.css
+      ".output/chrome-mv3/assets/one.css
       ----------------------------------------
       body{color:#00f}
 
       ================================================================================
-      .output/chrome-mv3/assets/two-74d94aed.css
+      .output/chrome-mv3/assets/two.css
       ----------------------------------------
       body{color:red}
 
@@ -70,7 +70,7 @@ describe('Output Directory Structure', () => {
       ================================================================================
       .output/chrome-mv3/manifest.json
       ----------------------------------------
-      {\\"manifest_version\\":3,\\"name\\":\\"E2E Extension\\",\\"version\\":\\"0.0.0\\",\\"version_name\\":\\"0.0.0-test\\",\\"content_scripts\\":[{\\"matches\\":[\\"*://*/*\\"],\\"css\\":[\\"assets/one-dedc7a05.css\\",\\"assets/two-74d94aed.css\\"],\\"js\\":[\\"content-scripts/one.js\\",\\"content-scripts/two.js\\"]}]}"
+      {\\"manifest_version\\":3,\\"name\\":\\"E2E Extension\\",\\"version\\":\\"0.0.0\\",\\"version_name\\":\\"0.0.0-test\\",\\"content_scripts\\":[{\\"matches\\":[\\"*://*/*\\"],\\"css\\":[\\"assets/one.css\\",\\"assets/two.css\\"],\\"js\\":[\\"content-scripts/one.js\\",\\"content-scripts/two.js\\"]}]}"
     `);
   });
 });

--- a/src/core/build/buildEntrypoints.ts
+++ b/src/core/build/buildEntrypoints.ts
@@ -63,7 +63,7 @@ async function buildSingleEntrypoint(
           // Output content script CSS to assets/ with a hash to prevent conflicts. Defaults to
           // "[name].[ext]" in lib mode, which usually results in "style.css". That means multiple
           // content scripts with styles would overwrite each other if it weren't changed below.
-          assetFileNames: `assets/${entrypoint.name}-[hash].[ext]`,
+          assetFileNames: `assets/${entrypoint.name}.[ext]`,
         },
       },
     },

--- a/src/core/utils/manifest.ts
+++ b/src/core/utils/manifest.ts
@@ -356,9 +356,8 @@ function getContentScriptCssFiles(
   const css: string[] = [];
 
   contentScripts.forEach((script) => {
-    const cssRegex = new RegExp(`^assets/${script.name}-[a-f0-9]{8}.css$`);
-    const relatedCss = buildOutput.find((chunk) =>
-      chunk.fileName.match(cssRegex),
+    const relatedCss = buildOutput.find(
+      (chunk) => chunk.fileName === `assets/${script.name}.css`,
     );
     if (relatedCss) css.push(relatedCss.fileName);
   });


### PR DESCRIPTION
Just cleaning up any unnecessary hashes from the output.