### PR TITLE
feat: Reload HTML files individually

### DIFF
--- a/e2e/tests/output-structure.test.ts
+++ b/e2e/tests/output-structure.test.ts
@@ -56,16 +56,12 @@ describe('Output Directory Structure', () => {
       ================================================================================
       .output/chrome-mv3/content-scripts/one.js
       ----------------------------------------
-      (function(){\\"use strict\\";function c(n){return n}const e=\\"\\",t={matches:[\\"*://*/*\\"],main:()=>{}};(async()=>{try{await t.main()}catch(n){console.error(\`The content script crashed on startup!
-
-      \`,n)}})()})();
+      (function(){\\"use strict\\";function i(n){return n}const s=\\"\\",o={matches:[\\"*://*/*\\"],main:()=>{}};function t(n,...e){if(typeof e[0]==\\"string\\"){const c=e.shift();n(\`[wxt] \${c}\`,...e)}else n(\\"[wxt]\\",...e)}var r={debug:(...n)=>t(console.debug,...n),log:(...n)=>t(console.log,...n),warn:(...n)=>t(console.warn,...n),error:(...n)=>t(console.error,...n)};(async()=>{try{await o.main()}catch(n){r.error(\\"The content script crashed on startup!\\",n)}})()})();
 
       ================================================================================
       .output/chrome-mv3/content-scripts/two.js
       ----------------------------------------
-      (function(){\\"use strict\\";function c(n){return n}const e=\\"\\",t={matches:[\\"*://*/*\\"],main:()=>{}};(async()=>{try{await t.main()}catch(n){console.error(\`The content script crashed on startup!
-
-      \`,n)}})()})();
+      (function(){\\"use strict\\";function i(n){return n}const s=\\"\\",o={matches:[\\"*://*/*\\"],main:()=>{}};function t(n,...e){if(typeof e[0]==\\"string\\"){const c=e.shift();n(\`[wxt] \${c}\`,...e)}else n(\\"[wxt]\\",...e)}var r={debug:(...n)=>t(console.debug,...n),log:(...n)=>t(console.log,...n),warn:(...n)=>t(console.warn,...n),error:(...n)=>t(console.error,...n)};(async()=>{try{await o.main()}catch(n){r.error(\\"The content script crashed on startup!\\",n)}})()})();
 
       ================================================================================
       .output/chrome-mv3/manifest.json

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -39,16 +39,24 @@ await Promise.all([
     silent: true,
   }),
   ...clientTemplates.map((templateName) =>
-  tsup.build({
+    tsup.build({
       entry: {
         [`templates/virtual-${templateName}`]: `src/client/templates/virtual-${templateName}.ts`,
       },
+      format: ['esm'],
+      sourcemap: true,
+      silent: true,
+      external: [`virtual:user-${templateName}`],
+    }),
+  ),
+  tsup.build({
+    entry: {
+      'templates/reload-html': `src/client/templates/reload-html.ts`,
+    },
     format: ['esm'],
     sourcemap: true,
     silent: true,
-      external: [`virtual:user-${templateName}`],
-    }),
-    ),
+  }),
 ]).catch((err) => {
   spinner.fail();
   console.error(err);

--- a/src/client/templates/reload-html.ts
+++ b/src/client/templates/reload-html.ts
@@ -1,0 +1,20 @@
+/// <reference types="vite/client" />
+
+import { logger } from '../utils/logger';
+import { setupWebSocket } from '../utils/setupWebSocket';
+
+if (__COMMAND__ === 'serve') {
+  try {
+    setupWebSocket((message) => {
+      if (message.event === 'wxt:reload-page') {
+        // We need to remove the initial slash from the path to compare correctly
+        // "popup.html" === "/popup.html".substring(1)
+        if (message.data === location.pathname.substring(1)) {
+          location.reload();
+        }
+      }
+    });
+  } catch (err) {
+    logger.error('Failed to setup web socket connection with dev server', err);
+  }
+}

--- a/src/client/templates/virtual-content-script.ts
+++ b/src/client/templates/virtual-content-script.ts
@@ -1,9 +1,10 @@
 import definition from 'virtual:user-content-script';
+import { logger } from '../utils/logger';
 
 (async () => {
   try {
     await definition.main();
   } catch (err) {
-    console.error('The content script crashed on startup!\n\n', err);
+    logger.error('The content script crashed on startup!', err);
   }
 })();

--- a/src/client/utils/setupWebSocket.ts
+++ b/src/client/utils/setupWebSocket.ts
@@ -33,7 +33,6 @@ export function setupWebSocket(
     try {
       const message = JSON.parse(e.data) as WebSocketMessage;
       if (message.type === 'custom' && message.event?.startsWith?.('wxt:')) {
-        logger.debug(`Recieved message: ${message.event}`, message);
         onMessage?.(message);
       }
     } catch (err) {

--- a/src/core/types/external.ts
+++ b/src/core/types/external.ts
@@ -58,6 +58,18 @@ export interface WxtDevServer extends vite.ViteDevServer {
    * Tell the extension to reload by running `browser.runtime.reload`.
    */
   reloadExtension: () => void;
+  /**
+   * Tell extension pages to reload if their path is in the list of paths provided.
+   *
+   * There are the bundle paths, not the input paths, so if the input paths is
+   * "src/options/index.html", you would pass "options.html" because that's where it is written to
+   * in the dist directory, and where it's available at in the actual extension.
+   *
+   * @example
+   * server.reloadPage("popup.html")
+   * server.reloadPage("sandbox.html")
+   */
+  reloadPage: (path: string) => void;
 }
 
 export type TargetBrowser = 'chrome' | 'firefox' | 'safari' | 'edge' | 'opera';

--- a/src/core/types/external.ts
+++ b/src/core/types/external.ts
@@ -59,9 +59,9 @@ export interface WxtDevServer extends vite.ViteDevServer {
    */
   reloadExtension: () => void;
   /**
-   * Tell extension pages to reload if their path is in the list of paths provided.
+   * Tell an extension page to reload.
    *
-   * There are the bundle paths, not the input paths, so if the input paths is
+   * The path is the bundle path, not the input paths, so if the input paths is
    * "src/options/index.html", you would pass "options.html" because that's where it is written to
    * in the dist directory, and where it's available at in the actual extension.
    *

--- a/src/core/utils/detectDevChanges.ts
+++ b/src/core/utils/detectDevChanges.ts
@@ -60,6 +60,17 @@ export function detectDevChanges(
     }
   }
 
+  const isOnlyHtmlChanges = !changedFiles.find(
+    ([_, file]) => !file.endsWith('.html'),
+  );
+  if (isOnlyHtmlChanges) {
+    return {
+      type: 'html-reload',
+      cachedOutput: unchangedOutput,
+      rebuildGroups: changedOutput.steps.map((step) => step.entrypoints),
+    };
+  }
+
   return {
     type: 'extension-reload',
     cachedOutput: unchangedOutput,
@@ -103,10 +114,7 @@ function findEffectedSteps(
  * Contains information about what files changed, what needs rebuilt, and the type of reload that is
  * required.
  */
-export type DevModeChange =
-  | NoChange
-  // | HtmlReload
-  | ExtensionReload;
+export type DevModeChange = NoChange | HtmlReload | ExtensionReload;
 // | BrowserRestart
 // | ContentScriptReload
 
@@ -125,15 +133,9 @@ interface RebuildChange {
   cachedOutput: BuildOutput;
 }
 
-/**
- * This is separate from `ExtensionReload` because if an HTML file changes, for some browsers,
- * reloading the current page is enough to pull from the latest change. Simply reloading the page is
- * less destructive then reloading the entire extension (content scripts aren't invalidated, tabs to
- * extension pages aren't closed, etc).
- */
-// interface HtmlReload extends RebuildChange {
-//   type: 'html-reload';
-// }
+interface HtmlReload extends RebuildChange {
+  type: 'html-reload';
+}
 
 interface ExtensionReload extends RebuildChange {
   type: 'extension-reload';

--- a/src/core/vite-plugins/devHtmlPrerender.ts
+++ b/src/core/vite-plugins/devHtmlPrerender.ts
@@ -11,6 +11,21 @@ export function devHtmlPrerender(config: InternalConfig): vite.Plugin {
   return {
     apply: 'build',
     name: 'wxt:dev-html-prerender',
+    config(userConfig) {
+      return vite.mergeConfig(
+        {
+          resolve: {
+            alias: {
+              '@wxt/reload-html': resolve(
+                config.root,
+                'node_modules/wxt/dist/templates/reload-html.js',
+              ),
+            },
+          },
+        },
+        userConfig,
+      );
+    },
     async transform(html, id) {
       const server = config.server;
       if (config.command !== 'serve' || server == null || !id.endsWith('.html'))
@@ -42,6 +57,12 @@ export function devHtmlPrerender(config: InternalConfig): vite.Plugin {
       };
       pointToDevServer('script[type=module]', 'src');
       pointToDevServer('link[rel=stylesheet]', 'href');
+
+      // Add a script to add page reloading
+      const reloader = document.createElement('script');
+      reloader.src = '@wxt/reload-html';
+      reloader.type = 'module';
+      document.head.appendChild(reloader);
 
       const newHtml = document.toString();
       config.logger.debug('Transformed ' + id);


### PR DESCRIPTION
This closes #2 

When changing an HTML file, instead of reloading the entire extension, just refresh the effected pages. This lets the background script and content scripts continue running without being restarted.

Vite's HMR logic doesn't work in this case because it only effects pages ending in `index.html`, so we have to do it ourselves.