### PR TITLE
chore: Simplify binary setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,10 +28,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: |
-          pnpm install --ignore-scripts
-          pnpm build
-          pnpm install --ignore-scripts
+        run: pnpm install
 
       - name: Bump and Tag
         run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -30,11 +30,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: |
-          pnpm install --ignore-scripts
-          pnpm build
-          pnpm install --ignore-scripts
-          cd demo && pnpm wxt prepare
+        run: pnpm install
 
       - name: Formatting
         run: pnpm format:check

--- a/bin/wxt.cjs
+++ b/bin/wxt.cjs
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('../dist/cli.cjs');

--- a/package.json
+++ b/package.json
@@ -26,9 +26,10 @@
   },
   "license": "MIT",
   "files": [
+    "bin",
     "dist"
   ],
-  "bin": "dist/cli.cjs",
+  "bin": "./bin/wxt.cjs",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 import cac from 'cac';
 import { version } from '../../package.json';
 import * as commands from './commands';


### PR DESCRIPTION
Currently, since this is a monorepo, running `pnpm i` on a fresh clone, like in CI, fails since it needs to build the binary before it can link it in the node modules for the demo project.

Instead, you have to run install twice:

```sh
pnpm install --ignore-scripts
pnpm build
pnpm install
```

If instead, the entrypoint is a JS file committed to the project, the binary can be linked on the first install.