### PR TITLE
ci: Validate templates against `main`

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -76,6 +76,7 @@ jobs:
         working-directory: templates/vanilla
         run: |
           npm i
+          npm i ../../
           npm run build
           npm run compile
 
@@ -83,6 +84,7 @@ jobs:
         working-directory: templates/vue
         run: |
           npm i
+          npm i ../../
           npm run build
           npm run compile
 
@@ -90,6 +92,7 @@ jobs:
         working-directory: templates/react
         run: |
           npm i
+          npm i ../../
           npm run build
           npm run compile
 
@@ -97,6 +100,7 @@ jobs:
         working-directory: templates/svelte
         run: |
           npm i
+          npm i ../../
           npm run build
           npm run check
 
@@ -104,5 +108,6 @@ jobs:
         working-directory: templates/solid
         run: |
           npm i
+          npm i ../../
           npm run build
           npm run compile

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wxt",
   "type": "module",
-  "version": "0.3.1-alpha1",
+  "version": "0.3.1",
   "description": "Next gen framework for developing web extensions",
   "engines": {
     "node": ">=18.16.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wxt",
   "type": "module",
-  "version": "0.3.1",
+  "version": "0.3.1-alpha1",
   "description": "Next gen framework for developing web extensions",
   "engines": {
     "node": ">=18.16.0",


### PR DESCRIPTION
Templates broke when v0.3.1 was released because of the CSS entrypoints. The react and solid templates used `popup/index.css`, which results in two entrypoints with the same name.

https://github.com/aklinker1/wxt/actions/runs/5704132503/job/15457436014

Template validation should be ran against the current code, not the latest published version, and that will catch this sooner.