### PR TITLE
Fix templates

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -72,11 +72,14 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Build Local Tarball
+        run: pnpm pack
+
       - name: Validate Vanilla
         working-directory: templates/vanilla
         run: |
           npm i
-          npm i ../../
+          npm i -D ../../wxt-*.tgz
           npm ls vite
           npm run build
           npm run compile
@@ -85,7 +88,7 @@ jobs:
         working-directory: templates/vue
         run: |
           npm i
-          npm i ../../
+          npm i -D ../../wxt-*.tgz
           npm ls vite
           npm run build
           npm run compile
@@ -94,7 +97,7 @@ jobs:
         working-directory: templates/react
         run: |
           npm i
-          npm i ../../
+          npm i -D ../../wxt-*.tgz
           npm ls vite
           npm run build
           npm run compile
@@ -103,7 +106,7 @@ jobs:
         working-directory: templates/svelte
         run: |
           npm i
-          npm i ../../
+          npm i -D ../../wxt-*.tgz
           npm ls vite
           npm run build
           npm run check
@@ -112,7 +115,7 @@ jobs:
         working-directory: templates/solid
         run: |
           npm i
-          npm i ../../
+          npm i -D ../../wxt-*.tgz
           npm ls vite
           npm run build
           npm run compile

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -77,6 +77,7 @@ jobs:
         run: |
           npm i
           npm i ../../
+          npm ls vite
           npm run build
           npm run compile
 
@@ -85,6 +86,7 @@ jobs:
         run: |
           npm i
           npm i ../../
+          npm ls vite
           npm run build
           npm run compile
 
@@ -93,6 +95,7 @@ jobs:
         run: |
           npm i
           npm i ../../
+          npm ls vite
           npm run build
           npm run compile
 
@@ -101,6 +104,7 @@ jobs:
         run: |
           npm i
           npm i ../../
+          npm ls vite
           npm run build
           npm run check
 
@@ -109,5 +113,6 @@ jobs:
         run: |
           npm i
           npm i ../../
+          npm ls vite
           npm run build
           npm run compile

--- a/docs/get-started/introduction.md
+++ b/docs/get-started/introduction.md
@@ -2,7 +2,7 @@
 
 WXT is a free and open source framework for building web extensions in an conventional, intuative, and safe way **_for all browsers_**.
 
-WXT is based of [Nuxt](https://nuxt.com), and aims to provide the same great DX with TypeScript, Auto-imports, and an opinionated project structure.
+WXT is based of [Nuxt](https://nuxt.com), and aims to provide the same great DX with TypeScript, auto-imports, and an opinionated project structure.
 
 ![Example build output](../assets/cli-output.png)
 

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -23,12 +23,14 @@ await Promise.all([
     sourcemap: true,
     dts: true,
     silent: true,
+    external: ['vite'],
   }),
   tsup.build({
     entry: { cli: 'src/cli/index.ts' },
     format: ['cjs'],
     sourcemap: 'inline',
     silent: true,
+    external: ['vite'],
   }),
   tsup.build({
     entry: { client: 'src/client/index.ts' },
@@ -36,6 +38,7 @@ await Promise.all([
     sourcemap: 'inline',
     dts: true,
     silent: true,
+    external: ['vite'],
   }),
   tsup.build({
     entry: { browser: 'src/client/browser.ts' },
@@ -43,6 +46,7 @@ await Promise.all([
     sourcemap: 'inline',
     dts: true,
     silent: true,
+    external: ['vite'],
   }),
   ...virtualEntrypoints.map((entryName) =>
     tsup.build({
@@ -52,7 +56,7 @@ await Promise.all([
       format: ['esm'],
       sourcemap: true,
       silent: true,
-      external: [`virtual:user-${entryName}`],
+      external: [`virtual:user-${entryName}`, 'vite'],
     }),
   ),
   tsup.build({
@@ -62,6 +66,7 @@ await Promise.all([
     format: ['esm'],
     sourcemap: true,
     silent: true,
+    external: ['vite'],
   }),
   tsup.build({
     entry: {
@@ -69,6 +74,7 @@ await Promise.all([
     },
     format: ['esm', 'cjs'],
     silent: true,
+    external: ['vite'],
   }),
 ]).catch((err) => {
   spinner.fail();


### PR DESCRIPTION
Types were broken after a new version of Vite was released.

https://github.com/aklinker1/wxt/actions/runs/5841845307/job/15842377107

Essentially, because I was linking the local version of WXT to the templates, it was using the node_modules from the root PNPM install inside the declaration file defining what the `wxt.config.ts` file looks like. So the vite versions were conflicting between the `wxt/node_modules` and the `wxt/templates/vue/node_modules` directories.

Simply packing the local version of WXT solves this issue because the tarball doesn't include a `node_modules` directory.

Templates weren't actually broken when using them, they were only broken in CI.