### PR TITLE
chore: Improve file list output in CI

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -82,9 +82,13 @@ await Promise.all([
   process.exit(1);
 });
 
-spinner.succeed();
+spinner.clear().stop();
 
 const duration = Date.now() - startTime;
 const outFiles = await glob(`${outDir}/**`, { absolute: true });
-await printFileList(consola.log, outDir, outFiles);
-consola.success(`Finished in ${formatDuration(duration)}`);
+await printFileList(
+  consola.success,
+  `Built WXT in ${formatDuration(duration)}`,
+  outDir,
+  outFiles,
+);

--- a/src/core/build.ts
+++ b/src/core/build.ts
@@ -42,10 +42,12 @@ export async function buildInternal(
   const { output } = await rebuild(config, groups, undefined);
 
   // Post-build
-  config.logger.success(
+  await printBuildSummary(
+    config.logger.success,
     `Built extension in ${formatDuration(Date.now() - startTime)}`,
+    output,
+    config,
   );
-  await printBuildSummary(output, config);
 
   return output;
 }

--- a/src/core/log/printBuildSummary.ts
+++ b/src/core/log/printBuildSummary.ts
@@ -3,6 +3,8 @@ import { BuildOutput, InternalConfig } from '../types';
 import { printFileList } from './printFileList';
 
 export async function printBuildSummary(
+  log: (...args: any[]) => void,
+  header: string,
   output: BuildOutput,
   config: InternalConfig,
 ) {
@@ -18,7 +20,7 @@ export async function printBuildSummary(
   });
 
   const files = chunks.map((chunk) => resolve(config.outDir, chunk.fileName));
-  await printFileList(config.logger.log, config.outDir, files);
+  await printFileList(log, header, config.outDir, files);
 }
 
 const DEFAULT_SORT_WEIGHT = 100;

--- a/src/core/log/printFileList.ts
+++ b/src/core/log/printFileList.ts
@@ -6,6 +6,7 @@ import { printTable } from './printTable';
 
 export async function printFileList(
   log: (message: string) => void,
+  header: string,
   baseDir: string,
   files: string[],
 ): Promise<void> {
@@ -29,9 +30,9 @@ export async function printFileList(
     }),
   );
 
-  printTable(log, fileRows);
+  fileRows.push([`${pc.cyan('Σ Total size:')} ${String(filesize(totalSize))}`]);
 
-  log(`${pc.cyan('Σ Total size:')} ${String(filesize(totalSize))}`);
+  printTable(log, header, fileRows);
 }
 
 const DEFAULT_COLOR = pc.blue;

--- a/src/core/log/printTable.ts
+++ b/src/core/log/printTable.ts
@@ -1,5 +1,6 @@
 export function printTable(
   log: (message: string) => void,
+  header: string,
   rows: string[][],
   gap = 2,
 ): void {
@@ -24,5 +25,5 @@ export function printTable(
     if (i !== rows.length - 1) str += '\n';
   });
 
-  log(str);
+  log(`${header}\n${str}`);
 }

--- a/src/core/zip.ts
+++ b/src/core/zip.ts
@@ -66,10 +66,12 @@ export async function zipExtension(
     zipFiles.push(sourcesZipPath);
   }
 
-  config.logger.success(
+  await printFileList(
+    config.logger.success,
     `Zipped extension in ${formatDuration(Date.now() - start)}`,
+    config.outBaseDir,
+    zipFiles,
   );
-  await printFileList(config.logger.log, config.outBaseDir, zipFiles);
 
   return zipFiles;
 }


### PR DESCRIPTION
Tables now are printed in 1 log call along with their header and footer. In CI, this cleans up the alignment of the file list. In non-CI environments, this should be unnoticeable.

| Old | New |
| --- | --- |
| <img width="666" alt="Screenshot 2023-08-13 at 9 46 08 AM" src="https://github.com/aklinker1/wxt/assets/10101283/e57c16e4-9890-4b0f-9f28-61d3ea0e769b"> | <img width="645" alt="Screenshot 2023-08-13 at 9 49 07 AM" src="https://github.com/aklinker1/wxt/assets/10101283/506f5623-d493-4be7-b591-ca3b0373fdb9"> |