### PR TITLE
chore: Use import aliases in Vue template

### DIFF
--- a/templates/vue/entrypoints/popup/App.vue
+++ b/templates/vue/entrypoints/popup/App.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import HelloWorld from '../../components/HelloWorld.vue';
+import HelloWorld from '@/components/HelloWorld.vue';
 </script>
 
 <template>
@@ -8,7 +8,7 @@ import HelloWorld from '../../components/HelloWorld.vue';
       <img src="/wxt.svg" class="logo" alt="WXT logo" />
     </a>
     <a href="https://vuejs.org/" target="_blank">
-      <img src="../../assets/vue.svg" class="logo vue" alt="Vue logo" />
+      <img src="@/assets/vue.svg" class="logo vue" alt="Vue logo" />
     </a>
   </div>
   <HelloWorld msg="WXT + Vue" />


### PR DESCRIPTION
For some reason the import aliases weren't working in Vue. This was fixed in #95.