### PR TITLE
feat(cli): Add `wxt clean` command to delete generated files

### DIFF
--- a/src/cli/commands/clean.ts
+++ b/src/cli/commands/clean.ts
@@ -1,0 +1,44 @@
+import path from 'node:path';
+import { defineCommand } from '../utils/defineCommand';
+import glob from 'fast-glob';
+import fs from 'fs-extra';
+import { consola } from 'consola';
+import pc from 'picocolors';
+
+export const clean = defineCommand<
+  [
+    root: string | undefined,
+    flags: {
+      debug?: boolean;
+    },
+  ]
+>(async (root, flags) => {
+  consola.info('Cleaning Project');
+  const cwd = root ? path.resolve(root) : process.cwd();
+  const tempDirs = [
+    'node_modules/.vite',
+    'node_modules/.cache',
+    '**/.wxt',
+    '.output/*',
+  ];
+  consola.debug('Looking for:', tempDirs.map(pc.cyan).join(', '));
+  const directories = await glob(tempDirs, {
+    cwd,
+    absolute: true,
+    onlyDirectories: true,
+    deep: 2,
+  });
+  consola.debug(
+    'Found:',
+    directories
+      .map((dir) => pc.cyan(path.relative(process.cwd(), dir)))
+      .join(', '),
+  );
+
+  for (const directory of directories) {
+    await fs.rm(directory, { force: true, recursive: true });
+    consola.debug(
+      'Deleted ' + pc.cyan(path.relative(process.cwd(), directory)),
+    );
+  }
+});

--- a/src/cli/commands/clean.ts
+++ b/src/cli/commands/clean.ts
@@ -8,7 +8,4 @@ export const clean = defineCommand<
       debug?: boolean;
     },
   ]
->(async (root) => {
-  const cwd = root ?? process.cwd();
-  await wxt.clean(cwd);
-});
+>(wxt.clean);

--- a/src/cli/commands/clean.ts
+++ b/src/cli/commands/clean.ts
@@ -1,9 +1,5 @@
-import path from 'node:path';
 import { defineCommand } from '../utils/defineCommand';
-import glob from 'fast-glob';
-import fs from 'fs-extra';
-import { consola } from 'consola';
-import pc from 'picocolors';
+import * as wxt from '../..';
 
 export const clean = defineCommand<
   [
@@ -12,33 +8,7 @@ export const clean = defineCommand<
       debug?: boolean;
     },
   ]
->(async (root, flags) => {
-  consola.info('Cleaning Project');
-  const cwd = root ? path.resolve(root) : process.cwd();
-  const tempDirs = [
-    'node_modules/.vite',
-    'node_modules/.cache',
-    '**/.wxt',
-    '.output/*',
-  ];
-  consola.debug('Looking for:', tempDirs.map(pc.cyan).join(', '));
-  const directories = await glob(tempDirs, {
-    cwd,
-    absolute: true,
-    onlyDirectories: true,
-    deep: 2,
-  });
-  consola.debug(
-    'Found:',
-    directories
-      .map((dir) => pc.cyan(path.relative(process.cwd(), dir)))
-      .join(', '),
-  );
-
-  for (const directory of directories) {
-    await fs.rm(directory, { force: true, recursive: true });
-    consola.debug(
-      'Deleted ' + pc.cyan(path.relative(process.cwd(), directory)),
-    );
-  }
+>(async (root) => {
+  const cwd = root ?? process.cwd();
+  await wxt.clean(cwd);
 });

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -4,3 +4,4 @@ export * from './init';
 export * from './prepare';
 export * from './publish';
 export * from './zip';
+export * from './clean';

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -47,6 +47,7 @@ cli
 // CLEAN
 cli
   .command('clean [root]', 'clean generated files and caches')
+  .alias('cleanup')
   .action(commands.clean);
 
 // PUBLISH

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -40,9 +40,14 @@ cli
 
 // PREPARE
 cli
-  .command('prepare [root]', 'prepare')
+  .command('prepare [root]', 'prepare typescript project')
   .option('-c, --config <file>', 'use specified config file')
   .action(commands.prepare);
+
+// CLEAN
+cli
+  .command('clean [root]', 'clean generated files and caches')
+  .action(commands.clean);
 
 // PUBLISH
 cli.command('publish [root]', 'publish to stores').action(commands.publish);

--- a/src/core/clean.ts
+++ b/src/core/clean.ts
@@ -1,0 +1,36 @@
+import path from 'node:path';
+import glob from 'fast-glob';
+import fs from 'fs-extra';
+import { consola } from 'consola';
+import pc from 'picocolors';
+
+export async function clean(root: string) {
+  consola.info('Cleaning Project');
+  const tempDirs = [
+    'node_modules/.vite',
+    'node_modules/.cache',
+    '**/.wxt',
+    '.output/*',
+  ];
+  consola.debug('Looking for:', tempDirs.map(pc.cyan).join(', '));
+  const directories = await glob(tempDirs, {
+    cwd: path.resolve(root),
+    absolute: true,
+    onlyDirectories: true,
+    deep: 2,
+  });
+
+  if (directories.length > 0) {
+    consola.debug(
+      'Found:',
+      directories.map((dir) => pc.cyan(path.relative(root, dir))).join(', '),
+    );
+
+    for (const directory of directories) {
+      await fs.rm(directory, { force: true, recursive: true });
+      consola.debug('Deleted ' + pc.cyan(path.relative(root, directory)));
+    }
+  } else {
+    consola.debug('No generated files found.');
+  }
+}

--- a/src/core/clean.ts
+++ b/src/core/clean.ts
@@ -4,8 +4,14 @@ import fs from 'fs-extra';
 import { consola } from 'consola';
 import pc from 'picocolors';
 
-export async function clean(root: string) {
+/**
+ * Remove generated/temp files from the directory.
+ *
+ * @param root The directory to look for generated/temp files in. Defaults to `process.cwd()`. Can be relative to `process.cwd()` or absolute.
+ */
+export async function clean(root = process.cwd()) {
   consola.info('Cleaning Project');
+
   const tempDirs = [
     'node_modules/.vite',
     'node_modules/.cache',
@@ -19,18 +25,17 @@ export async function clean(root: string) {
     onlyDirectories: true,
     deep: 2,
   });
-
-  if (directories.length > 0) {
-    consola.debug(
-      'Found:',
-      directories.map((dir) => pc.cyan(path.relative(root, dir))).join(', '),
-    );
-
-    for (const directory of directories) {
-      await fs.rm(directory, { force: true, recursive: true });
-      consola.debug('Deleted ' + pc.cyan(path.relative(root, directory)));
-    }
-  } else {
+  if (directories.length === 0) {
     consola.debug('No generated files found.');
+    return;
+  }
+
+  consola.debug(
+    'Found:',
+    directories.map((dir) => pc.cyan(path.relative(root, dir))).join(', '),
+  );
+  for (const directory of directories) {
+    await fs.rm(directory, { force: true, recursive: true });
+    consola.debug('Deleted ' + pc.cyan(path.relative(root, directory)));
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import {
   setupServer,
 } from './core/server';
 
+export * from './core/clean';
 export { version } from '../package.json';
 export * from './core/types/external';
 export * from './core/utils/defineConfig';


### PR DESCRIPTION
Will delete the following directories:

- `node_modules/.vite`
- `node_modules/.cache`
- `**/.wxt`
- `.output/*`

Run `wxt prepare` or any other command to add them back.